### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ A super-simple set of pagination tools for Django 1.8+
 Documentation
 ------------------
 
-The full documentation will soon be at https://dj-paginator.readthedocs.org.
+The full documentation will soon be at https://dj-paginator.readthedocs.io.
 
 Features
 --------


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
